### PR TITLE
Fix entity type declaration

### DIFF
--- a/aip.php
+++ b/aip.php
@@ -37,14 +37,14 @@ function aip_civicrm_enable(): void {
 
 function aip_civicrm_entityTypes(&$entityTypes)
 {
-  $entityTypes['CRM_Aip_BAO_AipErrorLog'] = [
+  $entityTypes['CRM_Aip_DAO_AipErrorLog'] = [
           'name' => 'AipErrorLog',
-          'class' => 'CRM_Aip_BAO_AipErrorLog',
+          'class' => 'CRM_Aip_DAO_AipErrorLog',
           'table' => 'civicrm_aip_error_log'
   ];
-  $entityTypes['CRM_Aip_BAO_AipProcess'] = [
+  $entityTypes['CRM_Aip_DAO_AipProcess'] = [
           'name' => 'AipProcess',
-          'class' => 'CRM_Aip_BAO_AipProcess',
+          'class' => 'CRM_Aip_DAO_AipProcess',
           'table' => 'civicrm_aip_process'
   ];
 }

--- a/xml/schema/CRM/Aip/AipErrorLog.entityType.php
+++ b/xml/schema/CRM/Aip/AipErrorLog.entityType.php
@@ -4,7 +4,7 @@
 return [
   [
     'name' => 'AipErrorLog',
-    'class' => 'AipErrorLog',
+    'class' => 'CRM_Aip_DAO_AipErrorLog',
     'table' => 'civicrm_aip_error_log',
   ],
 ];


### PR DESCRIPTION
On entity type declaration the BAO class name instead of the DAO class name was used. That led to `NULL` as entity/object names in database hooks.

(BTW: I'm wondering if this extension runs on CiviCRM versions that still needs [hook_civicrm_entityTypes](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes/). Normally the `<entity name>.entityType.php` below `xml/schema/` are enough ...)

systopia-reference: 24544