### PR TITLE
continue with failed records

### DIFF
--- a/Civi/AIP/Process.php
+++ b/Civi/AIP/Process.php
@@ -260,8 +260,11 @@ class Process extends \Civi\AIP\AbstractComponent
    */
   public function continueWithFailedRecord() : bool
   {
-    // todo: setting?
-    return false;
+    if(!is_null($this->getConfigValue('continue_with_failed_record'))){
+      return true;
+    }else{
+      return false;
+    }
   }
 
   public function getTypeName() : string


### PR DESCRIPTION
AIP should be configurable to continue even if a record fails.