### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/Civi/Api4/Action/AipProcess/Run.php
+++ b/Civi/Api4/Action/AipProcess/Run.php
@@ -21,7 +21,6 @@ namespace Civi\Api4\Action\AipProcess;
 
 use \Civi\Api4\Generic\AbstractAction;
 use \Civi\Api4\Generic\Result;
-use CiviCRM_API3_Exception;
 use CRM_Core_Exception;
 
 /**
@@ -52,7 +51,7 @@ class Run extends AbstractAction {
     try {
       // todo refactor RUN implementation
       $api3_result = civicrm_api3('AIP', 'run_process', ['pid' => $this->process_id]);
-    } catch (CiviCRM_API3_Exception $exception) {
+    } catch (CRM_Core_Exception $exception) {
       throw new CRM_Core_Exception($exception->getMessage());
     }
     $result[] = $api3_result;

--- a/api/v3/AIP/RunProcess.php
+++ b/api/v3/AIP/RunProcess.php
@@ -37,7 +37,7 @@ function civicrm_api3_a_i_p_run_process($params)
 
   // verify pid parameter
   if (empty($params['pid'])) {
-    throw new CiviCRM_API3_Exception("Missing pid.");
+    throw new CRM_Core_Exception("Missing pid.");
   }
 
   // extract pIDs

--- a/tests/phpunit/Civi/AIP/Finder/DropFolderFinderTest.php
+++ b/tests/phpunit/Civi/AIP/Finder/DropFolderFinderTest.php
@@ -70,7 +70,7 @@ class DropFolderFinderTest extends TestBase implements HeadlessInterface, HookIn
       \civicrm_api3('Contact', 'getsingle', ['email' => 'anto@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'berty@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'cc@exis.ts']);
-    } catch (\CiviCRM_API3_Exception $ex) {
+    } catch (\CRM_Core_Exception $ex) {
       $this->fail("Contacts not created, the API calls probably didn't go through!");
     }
   }

--- a/tests/phpunit/Civi/AIP/Processor/Api3ProcessorTest.php
+++ b/tests/phpunit/Civi/AIP/Processor/Api3ProcessorTest.php
@@ -63,7 +63,7 @@ class Api3ProcessorTest extends TestBase implements HeadlessInterface, HookInter
       \civicrm_api3('Contact', 'getsingle', ['email' => 'anto@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'berty@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'cc@exis.ts']);
-    } catch (\CiviCRM_API3_Exception $ex) {
+    } catch (\CRM_Core_Exception $ex) {
       $this->fail("Contacts not created, the API calls probably didn't go through!");
     }
   }

--- a/tests/phpunit/Civi/AIP/Processor/ProcessorExceptionTest.php
+++ b/tests/phpunit/Civi/AIP/Processor/ProcessorExceptionTest.php
@@ -63,7 +63,7 @@ class ProcessorExceptionTest extends TestBase implements HeadlessInterface, Hook
       \civicrm_api3('Contact', 'getsingle', ['email' => 'anto@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'berty@exis.ts']);
       \civicrm_api3('Contact', 'getsingle', ['email' => 'cc@exis.ts']);
-    } catch (\CiviCRM_API3_Exception $ex) {
+    } catch (\CRM_Core_Exception $ex) {
       $this->fail("Contacts not created, the API calls probably didn't go through!");
     }
   }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.