### PR TITLE
Update deprecated php type casts

### DIFF
--- a/tests/phpunit/Civi/AIP/Processor/DelayedTestProcessor.php
+++ b/tests/phpunit/Civi/AIP/Processor/DelayedTestProcessor.php
@@ -30,7 +30,7 @@ class DelayedTestProcessor extends BaseProcessor
    */
   public function processRecord($record)
   {
-    $delay_time_seconds = (double) $this->getConfigValue('test/sleep_time_seconds', 0.0);
+    $delay_time_seconds = (float) $this->getConfigValue('test/sleep_time_seconds', 0.0);
     usleep($delay_time_seconds * 1000000);
     parent::processRecord($record);
     $this->processed_records++;


### PR DESCRIPTION
In PHP 8.5, non-canonical scalar type casts (boolean|double|integer|binary) are deprecated.

See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated